### PR TITLE
meson: Include revision number in version string

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,10 @@ tg_api_hash = get_option('tg_api_hash')
 
 if get_option('profile') == 'development'
   profile = 'Devel'
-  vcs_tag = run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()
+  vcs_tag = 'r' \
+    + run_command('git', 'rev-list', '--count', 'HEAD').stdout().strip() \
+    + '.' \
+    + run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()
   if vcs_tag == ''
     version_suffix = '-devel'
   else


### PR DESCRIPTION
Commit hashes do not make it easy to track the development status.
Therefore, like in 'https://aur.archlinux.org/packages/telegrand-git'
the revision number is included in the version string.