### PR TITLE
login: Fix actions not enabled after logout

### DIFF
--- a/src/login.rs
+++ b/src/login.rs
@@ -161,6 +161,9 @@ mod imp {
                 label.activate_action("tos.dialog", None);
                 gtk::Inhibit(true)
             });
+
+            // Disable all actions by default.
+            obj.disable_actions();
         }
     }
 
@@ -210,6 +213,12 @@ impl Login {
                 self.send_encryption_key();
             }
             AuthorizationState::WaitPhoneNumber => {
+                // The page 'phone-number-page' is the first page and thus the visible page by
+                // default. This means that no transition will happen when we receive
+                // 'WaitPhoneNumber'. In this case, we have to update the actions manually.
+                if self_.content.visible_child_name().unwrap() == "phone-number-page" {
+                    self.update_actions_for_visible_page();
+                }
                 self.navigate_to_page(
                     "phone-number-page",
                     [&*self_.phone_number_entry],


### PR DESCRIPTION
The actions on the 'phone-number-page' are not activated as soon as you
start Telegrand when you are already logged in and then log out again.

The reason for this is that in the match arm 'AuthorizationState::Ready'
all login actions are disabled. However, since the leafet has the
'phone-number-page' as its visible child by default,
'connect_visible_child_name_notify' is never fired when you log out.
Consequently, the actions are then never updated.

With this commit, all login actions are disabled by default when the
'Login' object is instantiated. It also checks in the match arm
'AuthorizationState::WaitPhoneNumber' if the actions need to be
manually updated when there is no transition.

![disabled_actions](https://user-images.githubusercontent.com/3630213/137413195-66e1a36b-b168-43a6-a8c4-a37ac14bc07e.png)
