### PR TITLE
Appdata related patches

### DIFF
--- a/data/app.drey.PaperPlane.metainfo.xml.in.in
+++ b/data/app.drey.PaperPlane.metainfo.xml.in.in
@@ -120,6 +120,9 @@
      <kudo>HiDpiIcon</kudo>
   </kudos>
   <developer_name translate="no">Marco Melorio</developer_name>
+  <developer id="io.github.paper-plane-developers">
+      <name translate="no">Marco Melorio</name>
+  </developer>
   <update_contact>marco.melorio@protonmail.com</update_contact>
   <translation type="gettext">@gettext-package@</translation>
   <launchable type="desktop-id">@app-id@.desktop</launchable>

--- a/data/app.drey.PaperPlane.metainfo.xml.in.in
+++ b/data/app.drey.PaperPlane.metainfo.xml.in.in
@@ -44,7 +44,7 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="0.1.0~beta.5" date="2023-11-03">
-      <description translatable="no">
+      <description translate="no">
         <p>This is the fifth beta release of Paper Plane 0.1.0 with new features and bug fixes:</p>
         <ul>
           <li>Archived chats can now be displayed. (#598, #607, #613)</li>
@@ -64,7 +64,7 @@
       </description>
     </release>
     <release version="0.1.0~beta.4" date="2023-09-25">
-      <description translatable="no">
+      <description translate="no">
         <p>This is the fourth beta release of Paper Plane 0.1.0 with new features and bug fixes:</p>
         <ul>
           <li>Paper Plane now uses some new shiny widgets from libadwaita 1.4, thanks to @melix99. (#518)</li>
@@ -82,7 +82,7 @@
       </description>
     </release>
     <release version="0.1.0~beta.3" date="2023-06-11">
-      <description translatable="no">
+      <description translate="no">
         <p>The third beta release of Paper Plane 0.1.0 should in the first place fix a build error on Flathub:</p>
         <ul>
           <li>Added registered categories to the desktop file to fix a build error on Flathub.</li>
@@ -92,7 +92,7 @@
       </description>
     </release>
     <release version="0.1.0~beta.2" date="2023-06-08">
-      <description translatable="no">
+      <description translate="no">
         <p>The second beta release of Paper Plane 0.1.0 contains the following features, fixes and chores:</p>
         <ul>
           <li>Blueprint compiler has been updated to version 0.8.1, thanks to @alissonlauffer.</li>
@@ -106,7 +106,7 @@
       </description>
     </release>
     <release version="0.1.0~beta.1" date="2023-05-16">
-      <description translatable="no">
+      <description translate="no">
         <p>Paper Plane 0.1.0-beta.1 is the first release for enthusiasts to try out and play around with.</p>
       </description>
     </release>
@@ -119,7 +119,7 @@
      <kudo>ModernToolkit</kudo>
      <kudo>HiDpiIcon</kudo>
   </kudos>
-  <developer_name translatable="no">Marco Melorio</developer_name>
+  <developer_name translate="no">Marco Melorio</developer_name>
   <update_contact>marco.melorio@protonmail.com</update_contact>
   <translation type="gettext">@gettext-package@</translation>
   <launchable type="desktop-id">@app-id@.desktop</launchable>

--- a/src/ui/session/contacts_window/mod.ui
+++ b/src/ui/session/contacts_window/mod.ui
@@ -1,6 +1,6 @@
 <interface>
   <template class="PaplContactsWindow" parent="AdwWindow">
-    <property name="title" translatable="true">Contacts</property>
+    <property name="title" translatable="yes">Contacts</property>
     <property name="modal">true</property>
     <property name="default-width">360</property>
     <property name="default-height">600</property>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer